### PR TITLE
Pass all files through `gofmt`

### DIFF
--- a/BinaryOption.go
+++ b/BinaryOption.go
@@ -1,11 +1,11 @@
-package GoIPQSDBReader;
+package GoIPQSDBReader
 
 type BinaryOption struct {
-	Data Bit;
+	Data Bit
 }
 
 func (bm *BinaryOption) Has(flag Bit) bool {
-	return bm.Data&flag != 0;
+	return bm.Data&flag != 0
 }
 
 // Binary Option Bit One

--- a/Bit.go
+++ b/Bit.go
@@ -1,3 +1,3 @@
-package GoIPQSDBReader;
+package GoIPQSDBReader
 
-type Bit uint8;
+type Bit uint8

--- a/Column.go
+++ b/Column.go
@@ -1,7 +1,7 @@
-package GoIPQSDBReader;
+package GoIPQSDBReader
 
 type Column struct {
-	Name string
-	Type *RecordType
+	Name     string
+	Type     *RecordType
 	RawValue string
 }

--- a/FileReader.go
+++ b/FileReader.go
@@ -1,4 +1,4 @@
-package GoIPQSDBReader;
+package GoIPQSDBReader
 
 import (
 	"bytes"
@@ -9,309 +9,307 @@ import (
 	"net"
 	"strconv"
 	"strings"
-);
+)
 
 type FileReader struct {
-	Handler bytes.Reader;
-	TotalBytes uint64;
-	RecordBytes uint64;
+	Handler     bytes.Reader
+	TotalBytes  uint64
+	RecordBytes uint64
 
-	TreeStart int64;
-	TreeEnd int64;
+	TreeStart int64
+	TreeEnd   int64
 
-	IPv6 bool;
-	Valid bool;
-	BinaryData bool;
-	Columns map[int]*Column;
+	IPv6       bool
+	Valid      bool
+	BinaryData bool
+	Columns    map[int]*Column
 
-	BlacklistFile bool;
+	BlacklistFile bool
 }
 
-func (file *FileReader) Fetch(ip string) (*IPQSRecord, error){
-	record := &IPQSRecord{};
+func (file *FileReader) Fetch(ip string) (*IPQSRecord, error) {
+	record := &IPQSRecord{}
 
-	if(file.IPv6 && strings.Contains(ip, ".")){
-		return record, errors.New("Attempted to look up IPv4 using IPv6 database file. Aborting.");
-	} else if(!file.IPv6 && strings.Contains(ip, ":")){
-		return record, errors.New("Attempted to look up IPv6 using IPv4 database file. Aborting.");
+	if file.IPv6 && strings.Contains(ip, ".") {
+		return record, errors.New("Attempted to look up IPv4 using IPv6 database file. Aborting.")
+	} else if !file.IPv6 && strings.Contains(ip, ":") {
+		return record, errors.New("Attempted to look up IPv6 using IPv4 database file. Aborting.")
 	}
 
-	if(!file.IPv6){
+	if !file.IPv6 {
 		_, subnet, _ := net.ParseCIDR("0.0.0.0/8")
 		incomingIP := net.ParseIP(ip)
-		if(subnet.Contains(incomingIP)) {
+		if subnet.Contains(incomingIP) {
 			return record, errors.New("Attempted to look up ip in 0.0.0.0/8 range. Aborting.")
 		}
 	}
 
-	position := 0;
-	previous := make(map[int]int64);
-	file_position := file.TreeStart + int64(5);
-	literal := convertIPToBinaryLitteral(file.IPv6, ip);
+	position := 0
+	previous := make(map[int]int64)
+	file_position := file.TreeStart + int64(5)
+	literal := convertIPToBinaryLitteral(file.IPv6, ip)
 
 	// Loop over tree. Will abort if we try too many times.
-	for l:=0;l<257;l++ {
-		previous[position] = file_position;
+	for l := 0; l < 257; l++ {
+		previous[position] = file_position
 
 		// Read tree.
-		if(len(literal) <= position){
-			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 8)");
-		}
-		
-		read := make([]byte, 8);
-
-		br, err := file.Handler.ReadAt(read, file_position);
-		if(br == 0 || err != nil){
-			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 9)");
+		if len(literal) <= position {
+			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 8)")
 		}
 
-		if(literal[position] == "0"){
+		read := make([]byte, 8)
+
+		br, err := file.Handler.ReadAt(read, file_position)
+		if br == 0 || err != nil {
+			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 9)")
+		}
+
+		if literal[position] == "0" {
 			file_position = int64(binary.LittleEndian.Uint32(read[0:4]))
 		} else {
-			file_position = int64(binary.LittleEndian.Uint32(read[4:8]));
+			file_position = int64(binary.LittleEndian.Uint32(read[4:8]))
 		}
 
-		if(!file.BlacklistFile){
-			if(file_position == 0){
+		if !file.BlacklistFile {
+			if file_position == 0 {
 				for i := 0; i <= position; i++ {
-					if(literal[position-i] == "1"){
-						literal[position-i] = "0";
-						
+					if literal[position-i] == "1" {
+						literal[position-i] = "0"
+
 						for n := (position - i + 1); n < len(literal); n++ {
-							literal[n] = "1";
+							literal[n] = "1"
 						}
 
-						position = position - i;
-						file_position = previous[position];
-						break;
+						position = position - i
+						file_position = previous[position]
+						break
 					}
 				}
 
-				continue;
+				continue
 			}
 		}
-		
-		if(file_position < file.TreeEnd){
-			if(file_position == 0){
-				break;
+
+		if file_position < file.TreeEnd {
+			if file_position == 0 {
+				break
 			}
-			
-			position++;
-			continue;
+
+			position++
+			continue
 		}
 
 		// In theory we're at a record.
-		raw := make([]byte, file.RecordBytes);
+		raw := make([]byte, file.RecordBytes)
 
-		br, err = file.Handler.ReadAt(raw, file_position);
-		if(br == 0 || err != nil){
-			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 11)");
+		br, err = file.Handler.ReadAt(raw, file_position)
+		if br == 0 || err != nil {
+			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 11)")
 		}
 
-		return parseRecord(record, raw, file);
+		return parseRecord(record, raw, file)
 	}
 
-	return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 12)");
+	return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 12)")
 }
 
-func parseRecord(record *IPQSRecord, raw []byte, file *FileReader) (*IPQSRecord, error){
-	current_byte := 0;
-	if(file.BinaryData){
+func parseRecord(record *IPQSRecord, raw []byte, file *FileReader) (*IPQSRecord, error) {
+	current_byte := 0
+	if file.BinaryData {
 		// Handle first three bits.
-		record.processFirstByte(&BinaryOption{Data: Bit(raw[0])});
-		record.processSecondByte(&BinaryOption{Data: Bit(raw[1])});
+		record.processFirstByte(&BinaryOption{Data: Bit(raw[0])})
+		record.processSecondByte(&BinaryOption{Data: Bit(raw[1])})
 
-		third := &BinaryOption{Data: Bit(raw[2])};
-		record.ConnectionType = createConnectionType(third);
-		record.AbuseVelocity = createAbuseVelocity(third);
-		current_byte = 3;
+		third := &BinaryOption{Data: Bit(raw[2])}
+		record.ConnectionType = createConnectionType(third)
+		record.AbuseVelocity = createAbuseVelocity(third)
+		current_byte = 3
 	} else {
 		// Handle first bit.
-		first := &BinaryOption{Data: Bit(raw[0])};
-		record.ConnectionType = createConnectionType(first);
-		record.AbuseVelocity = createAbuseVelocity(first);
-		current_byte = 1;
+		first := &BinaryOption{Data: Bit(raw[0])}
+		record.ConnectionType = createConnectionType(first)
+		record.AbuseVelocity = createAbuseVelocity(first)
+		current_byte = 1
 	}
 
-	record.FraudScore = &FraudScore{Strictness: make(map[int]int)};
-	
+	record.FraudScore = &FraudScore{Strictness: make(map[int]int)}
+
 	// Handle columns.
 	for i := 0; i < len(file.Columns); i++ {
-		c, e0 := file.Columns[i];
-		if(e0 == false){
-			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 12)");
+		c, e0 := file.Columns[i]
+		if e0 == false {
+			return record, errors.New("Invalid or nonexistent IP address specified for lookup. (EID: 12)")
 		}
 
-		var value string;
-		var err error;
-		switch(c.Name){
-			case "ASN":
-				i := int(binary.LittleEndian.Uint32(raw[current_byte:current_byte + 4]));
-				record.ASN = i;
-				value = strconv.Itoa(i);
+		var value string
+		var err error
+		switch c.Name {
+		case "ASN":
+			i := int(binary.LittleEndian.Uint32(raw[current_byte : current_byte+4]))
+			record.ASN = i
+			value = strconv.Itoa(i)
 
-				record.Columns = append(record.Columns, createColumn(c.Name, value, IntData));
-				current_byte += 4;
-			case "Latitude":
-				f := math.Float32frombits(binary.LittleEndian.Uint32(raw[current_byte:current_byte + 4]));
-				record.Latitude = f;
-				value = fmt.Sprintf("%f", f);
+			record.Columns = append(record.Columns, createColumn(c.Name, value, IntData))
+			current_byte += 4
+		case "Latitude":
+			f := math.Float32frombits(binary.LittleEndian.Uint32(raw[current_byte : current_byte+4]))
+			record.Latitude = f
+			value = fmt.Sprintf("%f", f)
 
-				record.Columns = append(record.Columns, createColumn(c.Name, value, FloatData));
-				current_byte += 4;
-			case "Longitude":
-				f := math.Float32frombits(binary.LittleEndian.Uint32(raw[current_byte:current_byte + 4]));
-				record.Longitude = f;
-				value = fmt.Sprintf("%f", f);
-				
-				record.Columns = append(record.Columns, createColumn(c.Name, value, FloatData));
-				current_byte += 4;
-			case "ZeroFraudScore":
-				i := int(uint8(raw[current_byte]));
-				record.FraudScore.Strictness[0] = i;
-				value = strconv.Itoa(i);
+			record.Columns = append(record.Columns, createColumn(c.Name, value, FloatData))
+			current_byte += 4
+		case "Longitude":
+			f := math.Float32frombits(binary.LittleEndian.Uint32(raw[current_byte : current_byte+4]))
+			record.Longitude = f
+			value = fmt.Sprintf("%f", f)
 
-				record.Columns = append(record.Columns, createColumn(c.Name, value, SmallIntData));
-				current_byte++;
-			case "OneFraudScore":
-				i := int(uint8(raw[current_byte]));
-				record.FraudScore.Strictness[1] = i;
-				value = strconv.Itoa(i);
+			record.Columns = append(record.Columns, createColumn(c.Name, value, FloatData))
+			current_byte += 4
+		case "ZeroFraudScore":
+			i := int(uint8(raw[current_byte]))
+			record.FraudScore.Strictness[0] = i
+			value = strconv.Itoa(i)
 
-				record.Columns = append(record.Columns, createColumn(c.Name, value, SmallIntData));
-				current_byte++;
-			default:
-				if(c.Type.Has(StringData)){
-					value, err = getRangedStringValue(file, raw[current_byte:current_byte+4]);
-					if(err != nil){
-						return record, errors.New("Invalid string data. (EID: 12)");
-					}
+			record.Columns = append(record.Columns, createColumn(c.Name, value, SmallIntData))
+			current_byte++
+		case "OneFraudScore":
+			i := int(uint8(raw[current_byte]))
+			record.FraudScore.Strictness[1] = i
+			value = strconv.Itoa(i)
 
-					record.Columns = append(record.Columns, createColumn(c.Name, value, StringData));
-					current_byte += 4;
+			record.Columns = append(record.Columns, createColumn(c.Name, value, SmallIntData))
+			current_byte++
+		default:
+			if c.Type.Has(StringData) {
+				value, err = getRangedStringValue(file, raw[current_byte:current_byte+4])
+				if err != nil {
+					return record, errors.New("Invalid string data. (EID: 12)")
 				}
+
+				record.Columns = append(record.Columns, createColumn(c.Name, value, StringData))
+				current_byte += 4
+			}
 		}
 
-		switch(c.Name){
-			case "Country":
-				record.Country = value;
-			case "City":
-				record.City = value;
-			case "Region":
-				record.Region = value;
-			case "ISP":
-				record.ISP = value;
-			case "Organization":
-				record.Organization = value;
-			case "Timezone":
-				record.Timezone = value;
-			case "Zipcode":
-				record.Zipcode = value;
-			case "Hostname":
-				record.Hostname = value;
+		switch c.Name {
+		case "Country":
+			record.Country = value
+		case "City":
+			record.City = value
+		case "Region":
+			record.Region = value
+		case "ISP":
+			record.ISP = value
+		case "Organization":
+			record.Organization = value
+		case "Timezone":
+			record.Timezone = value
+		case "Zipcode":
+			record.Zipcode = value
+		case "Hostname":
+			record.Hostname = value
 		}
 	}
 
-	return record, nil;
+	return record, nil
 }
 
-
-
 func createColumn(name string, value string, datatype Bit) *Column {
-	return &Column{Name: name, RawValue: value, Type: &RecordType{Data: datatype}};
+	return &Column{Name: name, RawValue: value, Type: &RecordType{Data: datatype}}
 }
 
 func getRangedStringValue(file *FileReader, pointer []byte) (string, error) {
-	position := binary.LittleEndian.Uint32(pointer);
-	sizeraw := make([]byte, 1);
-	br, err := file.Handler.ReadAt(sizeraw, int64(position));
-	if(br == 0 || err != nil){
-		return "", err;
+	position := binary.LittleEndian.Uint32(pointer)
+	sizeraw := make([]byte, 1)
+	br, err := file.Handler.ReadAt(sizeraw, int64(position))
+	if br == 0 || err != nil {
+		return "", err
 	}
 
-	size := int(uint8(sizeraw[0]));
-	raw := make([]byte, size);
-	br, err = file.Handler.ReadAt(raw, int64(position) + int64(1));
-	if(br == 0 || err != nil){
-		return "", err;
+	size := int(uint8(sizeraw[0]))
+	raw := make([]byte, size)
+	br, err = file.Handler.ReadAt(raw, int64(position)+int64(1))
+	if br == 0 || err != nil {
+		return "", err
 	}
 
-	return string(raw), nil;
+	return string(raw), nil
 }
 
 func createConnectionType(data *BinaryOption) *ConnectionType {
-	ct := &ConnectionType{};
-	if(data.Has(ConnectionTypeThree)){
-		if(data.Has(ConnectionTypeTwo)){
-			ct.Raw = 3;
-			return ct;
+	ct := &ConnectionType{}
+	if data.Has(ConnectionTypeThree) {
+		if data.Has(ConnectionTypeTwo) {
+			ct.Raw = 3
+			return ct
 		}
 
-		if(data.Has(ConnectionTypeOne)){
-			ct.Raw = 5;
-			return ct;
+		if data.Has(ConnectionTypeOne) {
+			ct.Raw = 5
+			return ct
 		}
 
-		ct.Raw = 1;
-		return ct;
+		ct.Raw = 1
+		return ct
 	}
 
-	if(data.Has(ConnectionTypeTwo)){
-		ct.Raw = 2;
-		return ct;
+	if data.Has(ConnectionTypeTwo) {
+		ct.Raw = 2
+		return ct
 	}
 
-	if(data.Has(ConnectionTypeOne)){
-		ct.Raw = 4;
-		return ct;
+	if data.Has(ConnectionTypeOne) {
+		ct.Raw = 4
+		return ct
 	}
 
-    ct.Raw = 0;
-	return ct;
+	ct.Raw = 0
+	return ct
 }
 
 func createAbuseVelocity(data *BinaryOption) *AbuseVelocity {
-	av := &AbuseVelocity{};
-	if(data.Has(AbuseVelocityTwo)){
-		if(data.Has(AbuseVelocityOne)){
-			av.Raw = 3;
-			return av;
+	av := &AbuseVelocity{}
+	if data.Has(AbuseVelocityTwo) {
+		if data.Has(AbuseVelocityOne) {
+			av.Raw = 3
+			return av
 		}
 
-		av.Raw = 1;
-		return av;
+		av.Raw = 1
+		return av
 	}
 
-	if(data.Has(AbuseVelocityOne)){
-		av.Raw = 2;
-		return av;
+	if data.Has(AbuseVelocityOne) {
+		av.Raw = 2
+		return av
 	}
 
-	av.Raw = 0;
-	return av;
+	av.Raw = 0
+	return av
 }
 
 func convertIPToBinaryLitteral(ipv6 bool, ip string) []string {
-	var result []string;
-	if(ipv6){
-		parts := "";
-		for _, n := range net.IP.To16(net.ParseIP(ip)){
-			parts = parts + fmt.Sprintf("%08b", n);
+	var result []string
+	if ipv6 {
+		parts := ""
+		for _, n := range net.IP.To16(net.ParseIP(ip)) {
+			parts = parts + fmt.Sprintf("%08b", n)
 		}
 
-		for i:=0;i<len(parts);i++ {
-			result = append(result, string(parts[i]));
+		for i := 0; i < len(parts); i++ {
+			result = append(result, string(parts[i]))
 		}
 	} else {
-		parts := "";
-		for _, n := range net.IP.To4(net.ParseIP(ip)){
-			parts = parts + fmt.Sprintf("%08b", n);
+		parts := ""
+		for _, n := range net.IP.To4(net.ParseIP(ip)) {
+			parts = parts + fmt.Sprintf("%08b", n)
 		}
 
-		for i:=0;i<len(parts);i++ {
-			result = append(result, string(parts[i]));
+		for i := 0; i < len(parts); i++ {
+			result = append(result, string(parts[i]))
 		}
 	}
 
-	return result;
+	return result
 }

--- a/GoIPQSDBReader.go
+++ b/GoIPQSDBReader.go
@@ -1,106 +1,106 @@
-package GoIPQSDBReader;
+package GoIPQSDBReader
 
 import (
-	"os";
-	"bytes";
-	"errors";
-	"encoding/binary";
-);
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"os"
+)
 
-var GOLANG_IPQS_READER_VERSION = byte(1);
+var GOLANG_IPQS_READER_VERSION = byte(1)
 
 func Open(filename string) (*FileReader, error) {
-	file := &FileReader{Columns: make(map[int]*Column)};
-	
-	var ferr error;
+	file := &FileReader{Columns: make(map[int]*Column)}
+
+	var ferr error
 	fileBytes, ferr := os.ReadFile(filename)
 	if ferr != nil {
 		return file, ferr
 	}
 
 	file.Handler = *bytes.NewReader(fileBytes)
-	
-	header := make([]byte, 11);
-	bl, err := file.Handler.Read(header);
-	if(err != nil || bl != 11){
-		return file, err;
+
+	header := make([]byte, 11)
+	bl, err := file.Handler.Read(header)
+	if err != nil || bl != 11 {
+		return file, err
 	}
 
-	fileheader := &BinaryOption{Data: Bit(header[0])};
-	file.BinaryData = fileheader.Has(BinaryData);
-	if(fileheader.Has(IPv4Map)){
-		file.Valid = true;
-		file.IPv6 = false;
+	fileheader := &BinaryOption{Data: Bit(header[0])}
+	file.BinaryData = fileheader.Has(BinaryData)
+	if fileheader.Has(IPv4Map) {
+		file.Valid = true
+		file.IPv6 = false
 	}
 
-	if(fileheader.Has(IPv6Map)){
-		file.Valid = true;
-		file.IPv6 = true;
+	if fileheader.Has(IPv6Map) {
+		file.Valid = true
+		file.IPv6 = true
 	}
 
-	if(fileheader.Has(IsBlacklistFile)){
-		file.BlacklistFile = true;
+	if fileheader.Has(IsBlacklistFile) {
+		file.BlacklistFile = true
 	}
 
-	if(file.Valid == false){
-		return file, errors.New("Invalid file format, invalid first byte, EID 1.");
-	}
-	
-	if(header[1] != GOLANG_IPQS_READER_VERSION){
-		return file, errors.New("Invalid file version, EID 1.");
+	if file.Valid == false {
+		return file, errors.New("Invalid file format, invalid first byte, EID 1.")
 	}
 
-	bytedata, _ := binary.Uvarint(header[2:5]);
-	if(bytedata == uint64(0)){
-		return file, errors.New("Invalid file format, invalid header bytes, EID 2.");
-	}
-	
-	file.RecordBytes, _ = binary.Uvarint(header[5:7]);
-	if(file.RecordBytes == uint64(0)){
-		return file, errors.New("Invalid file format, invalid record bytes, EID 3.");
+	if header[1] != GOLANG_IPQS_READER_VERSION {
+		return file, errors.New("Invalid file version, EID 1.")
 	}
 
-	file.TotalBytes = uint64(binary.LittleEndian.Uint32(header[7:11]));
-	if(file.TotalBytes == uint64(0)){
-		return file, errors.New("Invalid file format, EID 4.");
+	bytedata, _ := binary.Uvarint(header[2:5])
+	if bytedata == uint64(0) {
+		return file, errors.New("Invalid file format, invalid header bytes, EID 2.")
 	}
-	
-	file.TreeStart = int64(bytedata);
-	columns := make([]byte, bytedata - 11);
-	bl, err = file.Handler.Read(columns);
-	if(err != nil || bl != (int(bytedata) - 11)){
-		return file, err;
+
+	file.RecordBytes, _ = binary.Uvarint(header[5:7])
+	if file.RecordBytes == uint64(0) {
+		return file, errors.New("Invalid file format, invalid record bytes, EID 3.")
 	}
-	
-	for i:=0;i<((int(bytedata) - 11)/24);i++ {
+
+	file.TotalBytes = uint64(binary.LittleEndian.Uint32(header[7:11]))
+	if file.TotalBytes == uint64(0) {
+		return file, errors.New("Invalid file format, EID 4.")
+	}
+
+	file.TreeStart = int64(bytedata)
+	columns := make([]byte, bytedata-11)
+	bl, err = file.Handler.Read(columns)
+	if err != nil || bl != (int(bytedata)-11) {
+		return file, err
+	}
+
+	for i := 0; i < ((int(bytedata) - 11) / 24); i++ {
 		file.Columns[i] = &Column{
-            Name: string(bytes.Trim(columns[(i*24):((i+1)*24)-2], "\x00")), 
-            Type: &RecordType{Data: Bit(columns[(i*24)+23:((i+1)*24)][0])},
-        };
+			Name: string(bytes.Trim(columns[(i*24):((i+1)*24)-2], "\x00")),
+			Type: &RecordType{Data: Bit(columns[(i*24)+23 : ((i + 1) * 24)][0])},
+		}
 	}
 
-	if(len(file.Columns) == 0){
-		return file, errors.New("File does not appear to be valid, no column data found. EID: 5");
+	if len(file.Columns) == 0 {
+		return file, errors.New("File does not appear to be valid, no column data found. EID: 5")
 	}
 
-	treeheader := make([]byte, 5);
-	bl, err = file.Handler.Read(treeheader);
-	if(err != nil || bl != 5){
-		return file, err;
+	treeheader := make([]byte, 5)
+	bl, err = file.Handler.Read(treeheader)
+	if err != nil || bl != 5 {
+		return file, err
 	}
 
-    treetype := &RecordType{Data: Bit(treeheader[0])};
+	treetype := &RecordType{Data: Bit(treeheader[0])}
 
-	if(!treetype.Has(TreeData)){
-		return file, errors.New("File does not appear to be valid, bad binary tree. EID: 6");
+	if !treetype.Has(TreeData) {
+		return file, errors.New("File does not appear to be valid, bad binary tree. EID: 6")
 	}
 
-	totaltree := uint64(binary.LittleEndian.Uint32(treeheader[1:5]));
-	if(totaltree == 0){
-		return file, errors.New("File does not appear to be valid, tree size is too small. EID: 7");
+	totaltree := uint64(binary.LittleEndian.Uint32(treeheader[1:5]))
+	if totaltree == 0 {
+		return file, errors.New("File does not appear to be valid, tree size is too small. EID: 7")
 	}
 
-	file.TreeEnd = file.TreeStart + int64(totaltree);
-	
-	return file, nil;
+	file.TreeEnd = file.TreeStart + int64(totaltree)
+
+	return file, nil
 }

--- a/IPQSRecord.go
+++ b/IPQSRecord.go
@@ -1,36 +1,36 @@
-package GoIPQSDBReader;
+package GoIPQSDBReader
 
 type IPQSRecord struct {
-	IsProxy bool
-	IsVPN bool
-	IsTOR bool
-	IsCrawler bool
-	IsBot bool
-	RecentAbuse bool
-	IsBlacklisted bool
-	IsPrivate bool
-	IsMobile bool
-	HasOpenPorts bool
+	IsProxy           bool
+	IsVPN             bool
+	IsTOR             bool
+	IsCrawler         bool
+	IsBot             bool
+	RecentAbuse       bool
+	IsBlacklisted     bool
+	IsPrivate         bool
+	IsMobile          bool
+	HasOpenPorts      bool
 	IsHostingProvider bool
-	ActiveVPN bool
-	ActiveTOR bool
+	ActiveVPN         bool
+	ActiveTOR         bool
 	PublicAccessPoint bool
 
 	ConnectionType *ConnectionType
-	AbuseVelocity *AbuseVelocity
+	AbuseVelocity  *AbuseVelocity
 
-	Country string
-	City string
-	Region string
-	ISP string
+	Country      string
+	City         string
+	Region       string
+	ISP          string
 	Organization string
-	Zipcode string
-	Hostname string
-	ASN int
-	Timezone string
-	Latitude float32
-	Longitude float32
-	
+	Zipcode      string
+	Hostname     string
+	ASN          int
+	Timezone     string
+	Latitude     float32
+	Longitude    float32
+
 	FraudScore *FraudScore
 
 	Columns []*Column
@@ -49,91 +49,91 @@ type FraudScore struct {
 }
 
 func (conn *ConnectionType) ToString() string {
-	switch(conn.Raw){
-		case 1:
-			return "Residential";
-		case 2:
-			return "Mobile";
-		case 3:
-			return "Corporate";
-		case 4:
-			return "Data Center";
-		case 5:
-			return "Education";
-		default:
-			return "Unknown";
+	switch conn.Raw {
+	case 1:
+		return "Residential"
+	case 2:
+		return "Mobile"
+	case 3:
+		return "Corporate"
+	case 4:
+		return "Data Center"
+	case 5:
+		return "Education"
+	default:
+		return "Unknown"
 	}
 }
 
 func (av *AbuseVelocity) ToString() string {
-	switch(av.Raw) {
-		case 1:
-			return "low";
-		case 2:
-			return "medium";
-		case 3:
-			return "high";
-		default:
-			return "none";
+	switch av.Raw {
+	case 1:
+		return "low"
+	case 2:
+		return "medium"
+	case 3:
+		return "high"
+	default:
+		return "none"
 	}
 }
 
-func (record *IPQSRecord) processFirstByte(b *BinaryOption){
-	if(b.Has(IsProxy)){
-		record.IsProxy = true;
+func (record *IPQSRecord) processFirstByte(b *BinaryOption) {
+	if b.Has(IsProxy) {
+		record.IsProxy = true
 	}
 
-	if(b.Has(IsVPN)){
-		record.IsVPN = true;
+	if b.Has(IsVPN) {
+		record.IsVPN = true
 	}
 
-	if(b.Has(IsTOR)){
-		record.IsTOR = true;
+	if b.Has(IsTOR) {
+		record.IsTOR = true
 	}
 
-	if(b.Has(IsCrawler)){
-		record.IsCrawler = true;
+	if b.Has(IsCrawler) {
+		record.IsCrawler = true
 	}
 
-	if(b.Has(IsBot)){
-		record.IsBot = true;
+	if b.Has(IsBot) {
+		record.IsBot = true
 	}
 
-	if(b.Has(RecentAbuse)){
-		record.RecentAbuse = true;
+	if b.Has(RecentAbuse) {
+		record.RecentAbuse = true
 	}
 
-	if(b.Has(IsBlacklisted)){
-		record.IsBlacklisted = true;
+	if b.Has(IsBlacklisted) {
+		record.IsBlacklisted = true
 	}
 
-	if(b.Has(IsPrivate)){
-		record.IsPrivate = true;
+	if b.Has(IsPrivate) {
+		record.IsPrivate = true
 	}
 }
 
-func (record *IPQSRecord) processSecondByte(b *BinaryOption){
-	if(b.Has(IsMobile)){
-		record.IsMobile = true;
+func (record *IPQSRecord) processSecondByte(b *BinaryOption) {
+	if b.Has(IsMobile) {
+		record.IsMobile = true
 	}
 
-	if(b.Has(HasOpenPorts)){
-		record.HasOpenPorts = true;
+	if b.Has(HasOpenPorts) {
+		record.HasOpenPorts = true
 	}
 
-	if(b.Has(IsHostingProvider)){
-		record.IsHostingProvider = true;
+	if b.Has(IsHostingProvider) {
+		record.IsHostingProvider = true
 	}
 
-	if(b.Has(ActiveVPN)){
-		record.ActiveVPN = true;
+	if b.Has(ActiveVPN) {
+		record.ActiveVPN = true
 	}
 
-	if(b.Has(ActiveTOR)){
-		record.ActiveTOR = true;
+	if b.Has(ActiveTOR) {
+		record.ActiveTOR = true
 	}
 
-	if(b.Has(PublicAccessPoint)){
-		record.PublicAccessPoint = true;
+	if b.Has(PublicAccessPoint) {
+		record.PublicAccessPoint = true
 	}
 }

--- a/RecordType.go
+++ b/RecordType.go
@@ -1,7 +1,7 @@
-package GoIPQSDBReader;
+package GoIPQSDBReader
 
 type RecordType struct {
-	Data Bit;
+	Data Bit
 }
 
 const (
@@ -27,33 +27,33 @@ const (
 )
 
 func (bm *RecordType) Has(flag Bit) bool {
-	return bm.Data&flag != 0;
+	return bm.Data&flag != 0
 }
 
-func (bm *RecordType) Set(flag Bit) { 
-	bm.Data = bm.Data | flag;
+func (bm *RecordType) Set(flag Bit) {
+	bm.Data = bm.Data | flag
 }
 
 func (bm *RecordType) ToString() string {
-	if(bm.Has(TreeData)){
-		return "Tree";
+	if bm.Has(TreeData) {
+		return "Tree"
 	}
 
-	if(bm.Has(StringData)){
-		return "String";
+	if bm.Has(StringData) {
+		return "String"
 	}
 
-	if(bm.Has(SmallIntData)){
-		return "Small Int";
+	if bm.Has(SmallIntData) {
+		return "Small Int"
 	}
 
-	if(bm.Has(IntData)){
-		return "Int";
+	if bm.Has(IntData) {
+		return "Int"
 	}
 
-	if(bm.Has(FloatData)){
-		return "Float";
+	if bm.Has(FloatData) {
+		return "Float"
 	}
 
-	return "Unknown";
+	return "Unknown"
 }


### PR DESCRIPTION
I don't know if you accept contributions, but we've needed to fork this for some internal reasons. This branch is only stylistic: it records the result of running

```sh
gofmt -w .
```

This brings the code into alignment with Go's established style.

(For our fork, we'll want to map things into memory. Tricks with memfd_create(2) and mmap(2) to create a suitable memory-backed "file" for use with the IPQS reader work, but this leads to issues around reported memory use (and so with cgroups v2). I don't want to try and circumvent those issues. It'll be easier for me to change things to hold a pointer to a buffer and to avoid the tricks.)